### PR TITLE
EventSource endpoint to watch for mentions of a site or url

### DIFF
--- a/lib/routes/api.js
+++ b/lib/routes/api.js
@@ -10,12 +10,15 @@ var LRU = require('lru-cache'),
   options = require('../config'),
   WebMentionPing = require('../classes/webmentionping'),
   urlTools = require('../utils/url-tools'),
+  EventEmitter = require('events').EventEmitter,
   noop = function () {},
   mentionsCache,
   mentionsArguments,
   getMentions,
   pingSuccessResponse,
-  pingErrorResponse;
+  pingErrorResponse,
+  getEventSourceEmitter,
+  fireEventSource;
 
 mentionsCache = LRU({
   max: options.mentionsCacheLimit || 10000,
@@ -24,6 +27,20 @@ mentionsCache = LRU({
   }
 });
 
+var EVENT_SOURCE_EMITTERS = {};
+getEventSourceEmitter = function(args, opts) {
+  var key;
+  if (args.url) {
+    key = "url:" + args.url;
+  } else if (args.site) {
+    key = "site:" + args.site;
+  }
+  var e = EVENT_SOURCE_EMITTERS[key];
+  if (!e && opts && opts.create) {
+    EVENT_SOURCE_EMITTERS[key] = {count:0, e:new EventEmitter()};
+  }
+  return EVENT_SOURCE_EMITTERS[key];
+};
 
 // Utility functions
 
@@ -153,6 +170,19 @@ pingErrorResponse = function (res, err) {
   });
 };
 
+fireEventSource = function() {
+  var eForSite = getEventSourceEmitter({site: this.targetHost}),
+      eForUrl = getEventSourceEmitter({url: this.target}),
+      wmdata = {source: this.source, target: this.target};
+    if (eForSite) {
+      eForSite.e.emit("webmention", wmdata);
+      eForSite.count += 1;
+    }
+    if (eForUrl) {
+      eForUrl.e.emit("webmention", wmdata);
+      eForUrl.count += 1;
+    }
+};
 
 // Route setup
 
@@ -168,6 +198,21 @@ module.exports = function (app) {
     getMentions(mentionsArguments(req)).then(function (mentions) {
       res.send(mentions);
     });
+  });
+
+  app.get('/api/mentions/live', function (req, res) {
+    var e = getEventSourceEmitter(mentionsArguments(req), {create: true});
+    req.socket.setTimeout(Infinity);
+    e.e.on("webmention", function(wm) {
+      res.write("id:" + e.count + "\n");
+      res.write("data:" + JSON.stringify(wm) + "\n\n");
+    });
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive'
+    });
+    res.write('\n');
   });
 
   app.get('/api/webmention', function (req, res) {
@@ -202,6 +247,7 @@ module.exports = function (app) {
       .then(ping.createMention.bind(ping))
       .then(ping.saveMention.bind(ping))
       .then(syncFetching ? successResponse : noop)
+      .then(fireEventSource.bind(ping))
       .then(undefined, errorResponse);
   });
 };


### PR DESCRIPTION
Add a new endpoint, /api/mentions/live, which is an EventSource and therefore gives Instant Gratification to people wanting to know when webmentions have arrived for their sites and urls.

This would be a good fix for #11 if it had tests, which it doesn't, because I'm not sure how to test multiple listener stuff in the test framework.

Also, keeping this stuff in one big dict in memory is problematic if the service gets big enough to have lots of people listening, and totally stops working if the server gets sharded, but those are problems for another day.
