### PR TITLE
Add check for source==target

### DIFF
--- a/lib/routes/api.js
+++ b/lib/routes/api.js
@@ -454,7 +454,15 @@ module.exports = function (app) {
       });
       return;
     }
-
+    
+    if (source==target) {
+      res.status(400).json({
+        error: true,
+        message: '"source" and "target" URL are not allowed to be identical'
+      });
+      return;
+    }
+    
     // Process the ping
 
     broker


### PR DESCRIPTION
(partially?) Fixes #43 

This implements the basic check that `source` is not the same as `target` when submitted. Depending on how redirects are handled, this might not catch all cases (e.g. source being `https://`, target `http://`), but it should eliminate the basic case of a sender automatically sending WMs to every link and by accident submitting a WM for the permalink.